### PR TITLE
Fixed warnings

### DIFF
--- a/src/dns.h
+++ b/src/dns.h
@@ -53,7 +53,7 @@
 #include <stdint.h>
 #if defined(_WIN32)
 #  include <winsock2.h>
-#  include <wspiapi.h>
+#  include <ws2tcpip.h>
    typedef uint32_t in_addr_t;
 #else
 #   include <arpa/inet.h>

--- a/src/dns.h
+++ b/src/dns.h
@@ -53,7 +53,11 @@
 #include <stdint.h>
 #if defined(_WIN32)
 #  include <winsock2.h>
-#  include <ws2tcpip.h>
+#  ifdef _MSC_VER
+#    include <ws2tcpip.h>
+#  else
+#    include <wspiapi.h>
+#  endif
    typedef uint32_t in_addr_t;
 #else
 #   include <arpa/inet.h>


### PR DESCRIPTION
These commits were necessary to ensure warning-free building on Win32, WinRT, macOS, iOS, tvOS and Android.