### PR TITLE
Mdns mods

### DIFF
--- a/src/codec.c
+++ b/src/codec.c
@@ -1558,15 +1558,17 @@ static inline dns_rcode_t decode_rr_txt(
     if (data->parse.size < slen)
       return RCODE_FORMAT_ERROR;
       
-    if (data->dest.size < slen)
+    if (data->dest.size < slen + 2)
       return RCODE_NO_MEMORY;
       
-    memcpy(data->dest.ptr,data->parse.ptr,slen);
+    *data->dest.ptr = '<';
+    memcpy(data->dest.ptr + 1,data->parse.ptr,slen);
+    *(data->dest.ptr + 1 + slen) = '>';
     assert(slen <= len);
     
-    ptxt->len        += slen;
-    data->dest.ptr   += slen;
-    data->dest.size  -= slen;
+    ptxt->len        += slen + 2;
+    data->dest.ptr   += slen + 2;
+    data->dest.size  -= slen + 2;
     data->parse.ptr  += slen;
     data->parse.size -= slen;
     len              -= slen;

--- a/src/codec.c
+++ b/src/codec.c
@@ -377,7 +377,7 @@ static dns_rcode_t encode_question(
     return RCODE_NO_MEMORY;
     
   write_uint16(&data->packet,pquestion->type);
-  write_uint16(&data->packet,pquestion->class);
+  write_uint16(&data->packet,pquestion->class | (pquestion->qu ? 0x8000 : 0));
   
   return RCODE_OKAY;
 }

--- a/src/dns.h
+++ b/src/dns.h
@@ -295,6 +295,7 @@ typedef struct dns_question_t   /* RFC-1035 */
   char const  *name;
   dns_type_t   type;
   dns_class_t  class;
+  bool         qu;
 } dns_question_t;
 
 typedef struct dns_generic_t    /* RFC-1035 */


### PR DESCRIPTION
I am hoping to use this library to encode and decode mDNS queries and responses. It seems that the mDNS is mostly the same as unicast DNS, except for a few small differences which I aim to add to this PR as I encounter them.

The first change is the qu bit which is used to indicate a preference for a unicast response.

The other change relates to the way this library coalesces all the RR_TXT records into one string. With mDNS and specifically DNS-SD multiple RR_TXT records are used to store key-value pairs representing metadata for the discovered service. Since the strings were just concatenated this makes it difficult/impossible to identify the pairs. This commit wraps each RR_TXT record in angled brackets so they can be trivially parsed afterwards if necessary.

This may not be the best way though, perhaps the records shouldn't be coalesced in the first place?

https://en.wikipedia.org/wiki/Multicast_DNS
