### PR TITLE
Disable warnings when building with clang and MSVC

### DIFF
--- a/src/codec.c
+++ b/src/codec.c
@@ -66,14 +66,12 @@
 
 #include "dns.h"
 
-#ifdef __cplusplus
-#  if defined(__clang__)
-#    pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#  elif defined(_MSC_VER)
-#    pragma warning(disable:4244)
-#    pragma warning(disable:4267)
-#  endif
+#if defined(__clang__)
+#  pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#  pragma warning(disable:4244)
+#  pragma warning(disable:4267)
 #endif
 
 /*----------------------------------------------------------------------------

--- a/src/codec.c
+++ b/src/codec.c
@@ -69,8 +69,8 @@
 #if defined(__clang__)
 #  pragma clang diagnostic ignored "-Wshorten-64-to-32"
 #elif defined(_MSC_VER)
-#  pragma warning(disable:4244)
-#  pragma warning(disable:4267)
+#  pragma warning(disable:4244) /* ignore float to integer type conversion */
+#  pragma warning(disable:4267) /* ignore size_t to smaller type conversion */
 #endif
 
 /*----------------------------------------------------------------------------

--- a/src/codec.c
+++ b/src/codec.c
@@ -68,7 +68,6 @@
 
 #if defined(__clang__)
 #  pragma clang diagnostic ignored "-Wshorten-64-to-32"
-#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #elif defined(_MSC_VER)
 #  pragma warning(disable:4244)
 #  pragma warning(disable:4267)

--- a/src/codec.c
+++ b/src/codec.c
@@ -66,6 +66,16 @@
 
 #include "dns.h"
 
+#ifdef __cplusplus
+#  if defined(__clang__)
+#    pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#  elif defined(_MSC_VER)
+#    pragma warning(disable:4244)
+#    pragma warning(disable:4267)
+#  endif
+#endif
+
 /*----------------------------------------------------------------------------
 ; The folowing are used for memory allocation.  dns_decoded_t should be fine
 ; for alignment size, as it's good enough for alignment.  If some odd-ball


### PR DESCRIPTION
Whether compiling as C or C++, the code produces some warnings about converting between types of different sizes when compiling with clang and MSVC.

This PR disables these warnings.