### PR TITLE
Add support for bare metal embedded platforms

### DIFF
--- a/src/codec.c
+++ b/src/codec.c
@@ -56,18 +56,12 @@
 
 #define _GNU_SOURCE
 
-#if defined(_WIN32)
-#  include <winsock.h>
-#elif defined(__unix__)
-#  include <arpa/inet.h>
-#elif defined(__NEWLIB__)
+#if defined(__NEWLIB__)
 #  include <machine/endian.h>
 #  define htons(_x)    __htons(_x)
 #  define ntohs(_x)     __ntohs(_x)
 #elif defined(__BIONIC__)
 #  include <sys/endian.h>
-#else
-#  error No implementation of htons found
 #endif
 
 #include <stdio.h>

--- a/src/codec.c
+++ b/src/codec.c
@@ -57,17 +57,17 @@
 #define _GNU_SOURCE
 
 #if defined(_WIN32)
-  #include <winsock.h>
+#  include <winsock.h>
 #elif defined(__unix__)
-  #include <arpa/inet.h>
+#  include <arpa/inet.h>
 #elif defined(__NEWLIB__)
-  #include <machine/endian.h>
-  #define htons(_x)    __htons(_x)
-  #define ntohs(_x)     __ntohs(_x)
+#  include <machine/endian.h>
+#  define htons(_x)    __htons(_x)
+#  define ntohs(_x)     __ntohs(_x)
 #elif defined(__BIONIC__)
-  #include <sys/endian.h>
+#  include <sys/endian.h>
 #else
-  #error No implementation of htons found
+#  error No implementation of htons found
 #endif
 
 #include <stdio.h>

--- a/src/codec.c
+++ b/src/codec.c
@@ -56,6 +56,18 @@
 
 #define _GNU_SOURCE
 
+#if defined(_WIN32)
+  #include <winsock.h>
+#elif defined(__unix__)
+  #include <arpa/inet.h>
+#elif __has_include (<machine/endian.h>)
+  #include <machine/endian.h>
+  #define htons(_x)    __htons(_x)
+  #define ntohs(_x)     __ntohs(_x)
+#else
+  #error No implementation of htons found
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/codec.c
+++ b/src/codec.c
@@ -64,6 +64,8 @@
   #include <machine/endian.h>
   #define htons(_x)    __htons(_x)
   #define ntohs(_x)     __ntohs(_x)
+#elif defined(__BIONIC__)
+  #include <sys/endian.h>
 #else
   #error No implementation of htons found
 #endif

--- a/src/codec.c
+++ b/src/codec.c
@@ -60,7 +60,7 @@
   #include <winsock.h>
 #elif defined(__unix__)
   #include <arpa/inet.h>
-#elif __has_include (<machine/endian.h>)
+#elif defined(__NEWLIB__)
   #include <machine/endian.h>
   #define htons(_x)    __htons(_x)
   #define ntohs(_x)     __ntohs(_x)

--- a/src/dns.h
+++ b/src/dns.h
@@ -73,9 +73,9 @@
                uint32_t                u6_addr32[4];
        } in6_u;
 
-    #define s6_addr                        in6_u.u6_addr8
-    #define s6_addr16              in6_u.u6_addr16
-    #define s6_addr32              in6_u.u6_addr32
+#    define s6_addr                        in6_u.u6_addr8
+#    define s6_addr16              in6_u.u6_addr16
+#    define s6_addr32              in6_u.u6_addr32
    };
 #endif
 

--- a/src/dns.h
+++ b/src/dns.h
@@ -59,8 +59,24 @@
 #    include <wspiapi.h>
 #  endif
    typedef uint32_t in_addr_t;
-#else
+#elif defined(__unix__)
 #   include <arpa/inet.h>
+#else
+   // No platform implementation of in6_addr so we'll provide a simple one
+   typedef uint32_t in_addr_t;
+   struct in6_addr
+   {
+       union 
+       {
+               uint8_t         u6_addr8[16];
+               uint16_t                u6_addr16[8];
+               uint32_t                u6_addr32[4];
+       } in6_u;
+
+    #define s6_addr                        in6_u.u6_addr8
+    #define s6_addr16              in6_u.u6_addr16
+    #define s6_addr32              in6_u.u6_addr32
+   };
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
I need to use this library on bare metal ARM that does not have `arpa/inet.h` or `winsock.h`. This patch allows the library to work with [newlib](https://en.wikipedia.org/wiki/Newlib) which is a fairly popular embedded libc.