### PR TITLE
allow rr opt in answer if additional info section is empty

### DIFF
--- a/src/codec.c
+++ b/src/codec.c
@@ -2192,7 +2192,7 @@ dns_rcode_t dns_decode(dns_decoded_t *presponse,size_t *prsize,dns_packet_t cons
   ; section.  Check that we haven't seen one before.
   ;-------------------------------------------------------------*/
   
-  if (context.edns) return RCODE_FORMAT_ERROR;
+  if (context.edns && response->arcount > 0) return RCODE_FORMAT_ERROR;
   
   for (size_t i = 0 ; i < response->arcount ; i++)
   {


### PR DESCRIPTION
Came across with windows server that send rr opt in answer section with empty additional info section.