### PR TITLE
Bug fix---Allow RR_OPT in answer section. And dns_encode to support rr_private.

### DIFF
--- a/src/codec.c
+++ b/src/codec.c
@@ -957,7 +957,13 @@ static dns_rcode_t encode_answer(
     
     case RR_NULL: rc = encode_rr_x(data,&answer->x); break;
     
-    default: rc = RCODE_NOT_IMPLEMENTED; break;
+    default:
+      if ((answer->generic.type >= RR_PRIVATE) && (answer->generic.type < RR_UNKNOWN))
+      {
+        rc = encode_rr_x(data,&answer->x);
+        break;
+      }
+      rc = RCODE_NOT_IMPLEMENTED; break;
   }
   
   if (rc != RCODE_OKAY)

--- a/src/codec.c
+++ b/src/codec.c
@@ -2187,13 +2187,6 @@ dns_rcode_t dns_decode(dns_decoded_t *presponse,size_t *prsize,dns_packet_t cons
       return rc;
   }
   
-  /*-------------------------------------------------------------
-  ; RR OPT can only appear once, and only in the additional info
-  ; section.  Check that we haven't seen one before.
-  ;-------------------------------------------------------------*/
-  
-  if (context.edns) return RCODE_FORMAT_ERROR;
-  
   for (size_t i = 0 ; i < response->arcount ; i++)
   {
     rc = decode_answer(&context,&response->additional[i]);


### PR DESCRIPTION
- Bug fix---Allow RR_OPT in answer section.
  There is not need for edns (rr opt) exists check before parsing
  additional section since decode_rr_opt() already checks if edns is
  already set. This allows rr_opt to be exists in answer section which
  I came accross recently with a windows server that send rr opt in
  answer section with empty additional info section.

- dns_encode to support rr_private.